### PR TITLE
Fixed AWS VPC command

### DIFF
--- a/how-to-guides/existing-network/connecting-to-aws.md
+++ b/how-to-guides/existing-network/connecting-to-aws.md
@@ -40,7 +40,7 @@ sudo sysctl -p /etc/sysctl.conf
 8. Connect to DevZero network:
 
 ```
-sudo dz net connect --ssh --advertise-routes=10.0.0.0/24,10.0.1.0/24
+sudo dz net connect --ssh --advertise-routes=<VPC_CIDR>
 ```
 
 9. Verify that the machine was connected to your DevZero network:\


### PR DESCRIPTION
The previous AWS VPC IP forwarding command had specific routes that could not validate the connection if it was wrong. So, generalize the command so the user knows they must put it in their VPC CIDR routes.