### PR TITLE
adds redirect to create new workspace 

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,4 @@
+root: ./
+
+redirects:
+  recipes/new-recipe: recipes/create-recipe.md


### PR DESCRIPTION
fixes issue where quickstart recipes were pointed to old url

using docs: https://docs.gitbook.com/integrations/git-sync/content-configuration#redirects but will need to verify this works as expected in staging