### PR TITLE
Fix how-to-guide all VPC

### DIFF
--- a/how-to-guides/existing-network/connecting-to-aws.md
+++ b/how-to-guides/existing-network/connecting-to-aws.md
@@ -27,7 +27,7 @@ curl -fsSL https://get.devzero.io | sh
 6. Log into your account by executing:
 
 ```
-dz auth login
+sudo dz auth login && sudo dz net connect
 ```
 
 7. Enable IP forwarding to access resources on private subnets:

--- a/how-to-guides/existing-network/connecting-to-azure.md
+++ b/how-to-guides/existing-network/connecting-to-azure.md
@@ -52,7 +52,7 @@ curl -fsSL https://get.devzero.io | sh
 2. Log into your account by executing:
 
 ```
-dz auth login
+sudo dz auth login && sudo dz net connect
 ```
 
 3. Enable IP forwarding to access resources on private subnets:

--- a/how-to-guides/existing-network/connecting-to-gcp.md
+++ b/how-to-guides/existing-network/connecting-to-gcp.md
@@ -42,7 +42,7 @@ curl -fsSL https://get.devzero.io | sh
 
 {% code lineNumbers="false" %}
 ```
-dz auth login
+sudo dz auth login && sudo dz net connect
 ```
 {% endcode %}
 


### PR DESCRIPTION
Existing VPC docs had command `dz auth login` which only authenticated the cli but not connect to the network.
Changed it to `sudo dz auth login && sudo dz net connect`